### PR TITLE
refactor(phase-0): Standardize database names

### DIFF
--- a/src/MvcMusicStore/Web.config
+++ b/src/MvcMusicStore/Web.config
@@ -9,9 +9,9 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
-    <add name="MusicStoreEntities" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=MvcMusicStoreV3;Integrated Security=True" providerName="System.Data.SqlClient" />
+    <add name="MusicStoreEntities" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=MvcMusicStore;Integrated Security=True" providerName="System.Data.SqlClient" />
     <add name="IdentityConnection"
-     connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=MvcMusicStoreUsersV3;Integrated Security=True" providerName="System.Data.SqlClient" />
+     connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=MvcMusicStoreUsers;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />


### PR DESCRIPTION
PR Title: refactor(phase-0): Standardize database names

PR Body:
Phase 0 cleanup: Remove "V3" suffix from database names in Web.config to match dependency-inventory.md standards.

**Changes:**
- MvcMusicStoreV3 → MvcMusicStore
- MvcMusicStoreUsersV3 → MvcMusicStoreUsers

Verified locally - app runs and connects correctly.

**Context:** Web.config from seed project used V3 naming. Standardizing before Phase 1 baseline work begins.